### PR TITLE
config/karma.conf.js missing in watch:browser task

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "lint:tests": "eslint test/specs/",
     "lint:source": "eslint src/",
     "watch:server": "npm run test:server -- --watch",
-    "watch:browser": "./node_modules/.bin/karma start --auto-watch --no-single-run",
+    "watch:browser": "./node_modules/.bin/karma start config/karma.conf.js --auto-watch --no-single-run",
     "packages": "npm list --depth=0",
     "package:purge": "rm -rf node_modules",
     "package:reinstall": "npm run package:purge && npm install",


### PR DESCRIPTION
Before:

> karma start --auto-watch --no-single-run

21 02 2016 14:11:51.818:WARN [karma]: No captured browser, open http://localhost
:9876/
21 02 2016 14:11:51.828:INFO [karma]: Karma v0.13.21 server started at http://lo
calhost:9876/
21 02 2016 14:11:59.196:INFO [Chrome 48.0.2564 (Windows 7 0.0.0)]: Connected on
socket /#penYBuAdKNBVruDVAAAA with id manual-3861
Chrome 48.0.2564 (Windows 7 0.0.0) ERROR
  You need to include some adapter that implements __karma__.start method!



After:

> karma start config/karma.conf.js --auto-watch --no-single-run

21 02 2016 14:25:22.563:WARN [karma]: No captured browser, open http://localhost
:9876/
21 02 2016 14:25:22.572:INFO [karma]: Karma v0.13.21 server started at http://lo
calhost:9876/
21 02 2016 14:25:22.578:INFO [launcher]: Starting browser Chrome
21 02 2016 14:25:25.432:INFO [Chrome 48.0.2564 (Windows 7 0.0.0)]: Connected on
socket /#tFP9tQoN3jcUl8QlAAAA with id manual-3594
21 02 2016 14:25:25.527:INFO [Chrome 48.0.2564 (Windows 7 0.0.0)]: Connected on
socket /#PzFgqWHRhQr0-u9KAAAB with id 29875496

START:
  Boily - UT for browser
    √ should not throw an error
    √ should be a object
    √ should contain 123
  Boily - UT for nodeJS
    √ should not throw
    √ should contain 123

Finished in 0.046 secs / 0.002 secs